### PR TITLE
feat: adding certificate-orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "agglayer-certificate-orchestrator"
+version = "0.1.0"
+dependencies = [
+ "agglayer-clock",
+ "anyhow",
+ "buildstructor",
+ "futures-util",
+ "pin-project 1.1.5",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "agglayer-clock"
 version = "0.1.0"
 dependencies = [
@@ -99,6 +114,7 @@ dependencies = [
 name = "agglayer-node"
 version = "0.1.0"
 dependencies = [
+ "agglayer-certificate-orchestrator",
  "agglayer-clock",
  "agglayer-config",
  "agglayer-signer",
@@ -117,6 +133,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "tower",

--- a/crates/agglayer-certificate-orchestrator/Cargo.toml
+++ b/crates/agglayer-certificate-orchestrator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agglayer-certificate-orchestrator"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+buildstructor.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+
+agglayer-clock = { path = "../agglayer-clock" }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
+futures-util = "0.3.30"
+pin-project = "1.1.5"

--- a/crates/agglayer-certificate-orchestrator/src/lib.rs
+++ b/crates/agglayer-certificate-orchestrator/src/lib.rs
@@ -1,0 +1,217 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use agglayer_clock::Event;
+use futures_util::{future::BoxFuture, Stream, StreamExt};
+use tokio::{
+    sync::mpsc::Receiver,
+    task::{JoinHandle, JoinSet},
+};
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
+use tracing::{debug, error};
+
+#[cfg(test)]
+mod tests;
+
+const MAX_POLL_READS: usize = 1_000;
+
+/// Certificate orchestrator that receives certificates from CDKs.
+/// It collects certificates and sends them to the epoch packer when an epoch
+/// ends.
+pub struct CertificateOrchestrator<C, A> {
+    /// Epoch packing task resolver.
+    epoch_packing_tasks: JoinSet<Result<(), Error>>,
+    /// Epoch packing task builder.
+    epoch_packing_task_builder: A,
+    /// Clock stream to receive EpochEnded events.
+    clock: C,
+    /// Certificates received from CDKs.
+    received_certificates: VecDeque<()>,
+    /// Certificates to pack for each epoch.
+    pub(crate) to_pack: BTreeMap<u64, VecDeque<()>>,
+    /// Receiver for certificates coming from CDKs.
+    data_receiver: Receiver<()>,
+    /// Cancellation token for graceful shutdown.
+    cancellation_token: Pin<Box<WaitForCancellationFutureOwned>>,
+}
+
+impl<C, A> CertificateOrchestrator<C, A> {
+    /// Creates a new CertificateOrchestrator instance.
+    pub(crate) fn new(
+        clock: C,
+        data_receiver: Receiver<()>,
+        cancellation_token: CancellationToken,
+        epoch_packing_task_builder: A,
+    ) -> Self {
+        Self {
+            epoch_packing_tasks: JoinSet::new(),
+            clock,
+            epoch_packing_task_builder,
+            data_receiver,
+            received_certificates: VecDeque::new(),
+            to_pack: BTreeMap::default(),
+            cancellation_token: Box::pin(cancellation_token.cancelled_owned()),
+        }
+    }
+}
+
+#[buildstructor::buildstructor]
+impl<C, A> CertificateOrchestrator<C, A>
+where
+    C: Stream<Item = Event> + Unpin + Send + 'static,
+    A: EpochPacker + Send,
+{
+    /// Function that setups and starts the CertificateOrchestrator.
+    ///
+    /// The available methods are:
+    ///
+    /// - `builder`: Creates a new builder instance.
+    /// - `clock`: Sets clock stream to receive EpochEnded events.
+    /// - `data_receiver`: Sets the receiver for certificates coming from CDKs.
+    /// - `cancellation_token`: Sets the cancellation token for graceful
+    ///   shutdown.
+    /// - `epoch_packing_builder`: Sets the task builder for epoch packing.
+    /// - `start`: Starts the CertificateOrchestrator.
+    ///
+    /// # Examples
+    /// ```
+    /// # use agglayer_certificate_orchestrator::Error;
+    /// # use agglayer_certificate_orchestrator::EpochPacker;
+    /// # use agglayer_certificate_orchestrator::CertificateOrchestrator;
+    /// # use tokio_stream::wrappers::BroadcastStream;
+    /// # use tokio_util::sync::CancellationToken;
+    /// # use futures_util::future::BoxFuture;
+    ///
+    /// ##[derive(Clone)]
+    /// pub struct AggregatorNotifier {}
+    ///
+    /// impl AggregatorNotifier {
+    ///     pub(crate) fn new() -> Self {
+    ///         Self {}
+    ///     }
+    /// }
+    ///
+    /// impl EpochPacker for AggregatorNotifier {
+    ///     fn pack<T: IntoIterator<Item = ()>>(
+    ///         &self,
+    ///         epoch: u64,
+    ///         to_pack: T,
+    ///     ) -> Result<BoxFuture<Result<(), Error>>, Error> {Ok(Box::pin(async move {Ok(())}))}
+    /// }
+    ///
+    /// async fn start() -> Result<(), ()> {
+    ///    let (sender, receiver) = tokio::sync::broadcast::channel(1);
+    ///    let clock_stream = BroadcastStream::new(sender.subscribe());
+    ///    let notifier = AggregatorNotifier::new();
+    ///    let data_receiver = tokio::sync::mpsc::channel(1).1;
+    ///
+    ///    CertificateOrchestrator::builder()
+    ///      .clock(clock_stream)
+    ///      .data_receiver(data_receiver)
+    ///      .cancellation_token(CancellationToken::new())
+    ///      .notification_task_builder(notifier)
+    ///      .start()
+    ///      .await
+    ///      .unwrap();
+    ///
+    ///    Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This function can't fail but returns a Result for convenience and future
+    ///
+    /// evolution.
+    #[builder(entry = "builder", exit = "start", visibility = "pub")]
+    pub async fn start(
+        clock: C,
+        data_receiver: Receiver<()>,
+        cancellation_token: CancellationToken,
+        epoch_packing_task_builder: A,
+    ) -> anyhow::Result<JoinHandle<()>> {
+        let orchestrator = Self::new(
+            clock,
+            data_receiver,
+            cancellation_token,
+            epoch_packing_task_builder,
+        );
+
+        let handle = tokio::spawn(orchestrator);
+
+        Ok(handle)
+    }
+}
+
+impl<C, A> Future for CertificateOrchestrator<C, A>
+where
+    C: Stream<Item = Event> + Send + Unpin + 'static,
+    A: EpochPacker,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Check if the orchestrator has been cancelled and should shutdown.
+        if self.cancellation_token.as_mut().poll(cx).is_ready() {
+            debug!("Certificate orchestrator cancelled by token");
+
+            return Poll::Ready(());
+        }
+
+        // Poll the notification tasks to check if any have errored.
+        match self.epoch_packing_tasks.poll_join_next(cx) {
+            Poll::Ready(Some(Ok(Err(error)))) => {
+                error!("Error during epoch packing: {:?}", error)
+            }
+            Poll::Ready(Some(Err(error))) => {
+                error!("Critical error during epoch packing: {:?}", error);
+            }
+            _ => {}
+        }
+
+        if let Some((epoch, certificates)) = self.to_pack.pop_first() {
+            debug!("Packing certificates for epoch {}", epoch);
+            // Create a new task to pack the certificates for this epoch
+            let task = self.epoch_packing_task_builder.clone();
+
+            self.epoch_packing_tasks
+                .spawn(async move { task.pack(epoch, certificates)?.await });
+        }
+
+        let mut received = vec![];
+        if let Poll::Ready(1usize..) =
+            self.data_receiver
+                .poll_recv_many(cx, &mut received, MAX_POLL_READS)
+        {
+            self.received_certificates.extend(received);
+
+            return self.poll(cx);
+        }
+
+        if let Poll::Ready(Some(Event::EpochEnded(epoch))) = self.clock.poll_next_unpin(cx) {
+            debug!("Epoch change event received: {}", epoch);
+
+            let to_pack = std::mem::take(&mut self.received_certificates);
+            self.to_pack.insert(epoch, to_pack);
+
+            return self.poll(cx);
+        }
+
+        Poll::Pending
+    }
+}
+
+pub trait EpochPacker: Clone + Unpin + Send + 'static {
+    fn pack<T: IntoIterator<Item = ()>>(
+        &self,
+        epoch: u64,
+        to_pack: T,
+    ) -> Result<BoxFuture<Result<(), Error>>, Error>;
+}
+
+#[derive(Debug)]
+pub enum Error {}

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -1,0 +1,137 @@
+use std::task::Poll;
+
+use futures_util::{future::BoxFuture, poll};
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+use tokio_util::sync::CancellationToken;
+
+use crate::{CertificateOrchestrator, EpochPacker, Error};
+
+// CertificateOrchestrator can be stopped
+#[tokio::test]
+async fn test_certificate_orchestrator_can_stop() {
+    let (_clock_sender, receiver) = broadcast::channel(1);
+    let clock = BroadcastStream::new(receiver).filter_map(|value| value.ok());
+
+    let (_data_sender, data_receiver) = mpsc::channel(10);
+    let cancellation_token = CancellationToken::new();
+
+    let (check_sender, mut check_receiver) = mpsc::channel(1);
+    let checker = Check::builder().executed(check_sender).build();
+
+    let mut orchestrator =
+        CertificateOrchestrator::new(clock, data_receiver, cancellation_token.clone(), checker);
+
+    cancellation_token.cancel();
+
+    assert!(matches!(poll!(&mut orchestrator), Poll::Ready(())));
+
+    assert!(orchestrator.to_pack.is_empty());
+    assert!(check_receiver.try_recv().is_err());
+}
+
+// Can collect certificates and pack them at the end of an epoch
+#[tokio::test]
+async fn test_collect_certificates() {
+    let (clock_sender, receiver) = broadcast::channel(1);
+    let clock = BroadcastStream::new(receiver).filter_map(|value| value.ok());
+    let (data_sender, data_receiver) = mpsc::channel(10);
+    let cancellation_token = CancellationToken::new();
+
+    let (check_sender, mut check_receiver) = mpsc::channel(1);
+    let check = Check::builder()
+        .executed(check_sender)
+        .expected_epoch(1)
+        .expected_certificates_len(1)
+        .build();
+
+    let mut orchestrator =
+        CertificateOrchestrator::new(clock, data_receiver, cancellation_token, check);
+
+    _ = data_sender.send(()).await;
+    _ = clock_sender.send(agglayer_clock::Event::EpochEnded(1));
+
+    let _poll = poll!(&mut orchestrator);
+
+    assert!(orchestrator.to_pack.is_empty());
+    assert!(check_receiver.recv().await.is_some());
+}
+
+// A certificate received after an EpochEnded is stored for next epoch
+#[tokio::test]
+async fn test_collect_certificates_after_epoch() {
+    let (clock_sender, receiver) = broadcast::channel(1);
+    let clock = BroadcastStream::new(receiver).filter_map(|value| value.ok());
+    let (data_sender, data_receiver) = mpsc::channel(10);
+    let cancellation_token = CancellationToken::new();
+
+    let (check_sender, mut check_receiver) = mpsc::channel(1);
+    let check = Check::builder()
+        .executed(check_sender)
+        .expected_epoch(1)
+        .expected_certificates_len(0)
+        .build();
+
+    let mut orchestrator =
+        CertificateOrchestrator::new(clock, data_receiver, cancellation_token, check);
+
+    _ = clock_sender.send(agglayer_clock::Event::EpochEnded(1));
+    let _poll = poll!(&mut orchestrator);
+
+    _ = data_sender.send(()).await;
+
+    let _poll = poll!(&mut orchestrator);
+
+    assert!(!orchestrator.received_certificates.is_empty());
+    assert!(check_receiver.recv().await.is_some());
+}
+
+// If no certificate is received, the orchestrator should send an empty payload
+#[tokio::test]
+async fn test_collect_certificates_when_empty() {
+    let (clock_sender, receiver) = broadcast::channel(1);
+    let clock = BroadcastStream::new(receiver).filter_map(|value| value.ok());
+    let (_data_sender, data_receiver) = mpsc::channel(10);
+    let cancellation_token = CancellationToken::new();
+
+    let (check_sender, mut check_receiver) = mpsc::channel(1);
+    let check = Check::builder()
+        .executed(check_sender)
+        .expected_epoch(1)
+        .expected_certificates_len(0)
+        .build();
+
+    let mut orchestrator =
+        CertificateOrchestrator::new(clock, data_receiver, cancellation_token, check);
+
+    _ = clock_sender.send(agglayer_clock::Event::EpochEnded(1));
+    let _poll = poll!(&mut orchestrator);
+
+    assert!(orchestrator.received_certificates.is_empty());
+    assert!(check_receiver.recv().await.is_some());
+}
+
+#[derive(buildstructor::Builder, Clone)]
+struct Check {
+    executed: mpsc::Sender<()>,
+    expected_epoch: Option<u64>,
+    expected_certificates_len: Option<usize>,
+}
+
+impl EpochPacker for Check {
+    fn pack<T>(&self, epoch: u64, to_pack: T) -> Result<BoxFuture<Result<(), Error>>, Error>
+    where
+        T: IntoIterator<Item = ()>,
+    {
+        if let Some(expected_epoch) = self.expected_epoch {
+            assert_eq!(epoch, expected_epoch);
+        }
+        if let Some(expected_certificates_len) = self.expected_certificates_len {
+            assert!(to_pack.into_iter().count() == expected_certificates_len);
+        }
+
+        _ = self.executed.try_send(());
+
+        Ok(Box::pin(async { Ok(()) }))
+    }
+}

--- a/crates/agglayer-config/src/certificate_orchestrator.rs
+++ b/crates/agglayer-config/src/certificate_orchestrator.rs
@@ -1,0 +1,21 @@
+use serde::Deserialize;
+
+/// The CertificateOrchestrator configuration.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct CertificateOrchestrator {
+    #[serde(default = "default_input_backpressure_buffer_size_default")]
+    pub input_backpressure_buffer_size: usize,
+}
+
+impl Default for CertificateOrchestrator {
+    fn default() -> Self {
+        Self {
+            input_backpressure_buffer_size: default_input_backpressure_buffer_size_default(),
+        }
+    }
+}
+
+fn default_input_backpressure_buffer_size_default() -> usize {
+    1_000
+}

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -16,6 +16,7 @@ use self::{rpc::deserialize_rpc_map, telemetry::TelemetryConfig};
 pub(crate) const DEFAULT_IP: std::net::Ipv4Addr = std::net::Ipv4Addr::new(0, 0, 0, 0);
 
 pub(crate) mod auth;
+pub(crate) mod certificate_orchestrator;
 pub(crate) mod epoch;
 pub(crate) mod l1;
 pub mod log;
@@ -66,6 +67,10 @@ pub struct Config {
     /// The list of configuration options used during shutdown.
     #[serde(default)]
     pub shutdown: ShutdownConfig,
+
+    /// The certificate orchestrator configuration.
+    #[serde(rename = "CertificateOrchestrator", default)]
+    pub certificate_orchestrator: certificate_orchestrator::CertificateOrchestrator,
 }
 
 impl Config {

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -18,7 +18,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true }
+tokio-util.workspace = true
 toml.workspace = true
 # Fixed until jsonrpsee update to hyper 1.0
 tower-http = { version = "0.4.0", features = ["full"] }
@@ -30,6 +30,8 @@ agglayer-config = { path = "../agglayer-config" }
 agglayer-clock = { path = "../agglayer-clock" }
 agglayer-telemetry = { path = "../agglayer-telemetry" }
 agglayer-signer = { path = "../agglayer-signer" }
+agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrator" }
+tokio-stream = "0.1.15"
 
 [dev-dependencies]
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.22.3" }

--- a/crates/agglayer-node/src/node/notifier.rs
+++ b/crates/agglayer-node/src/node/notifier.rs
@@ -1,0 +1,34 @@
+use agglayer_certificate_orchestrator::{EpochPacker, Error};
+use futures::future::BoxFuture;
+use tracing::debug;
+
+#[derive(Clone)]
+pub(crate) struct AggregatorNotifier {}
+
+impl AggregatorNotifier {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl EpochPacker for AggregatorNotifier {
+    fn pack<T: IntoIterator<Item = ()>>(
+        &self,
+        epoch: u64,
+        to_pack: T,
+    ) -> Result<BoxFuture<Result<(), Error>>, Error> {
+        // TODO: Implement the aggregator notifier.
+
+        let to_pack = to_pack.into_iter().collect::<Vec<_>>();
+
+        Ok(Box::pin(async move {
+            debug!(
+                "Start packing epoch {} with {} certificates",
+                epoch,
+                to_pack.len()
+            );
+
+            Ok(())
+        }))
+    }
+}


### PR DESCRIPTION
# Description

This PR introduces the `certificate-orchestrator`. 

The `certificate-orchestrator` is responsible for collecting the `certificates` coming from the CDKs (from JSON-RPC) and creating `epoch_packing` task when an Epoch ends.

The `epoch_packing` task implementation remains open and is not part of this PR.

This PR is part of #45

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
