### PR TITLE
fix: concurrency issues with fail and addr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
             cache-on-failure: true
 
       - name: Test
-        run: cargo nextest run --workspace
+        run: cargo nextest run --workspace && cargo test --doc --workspace
 
   pre-e2e:
     name: E2E Tests | Docker

--- a/crates/agglayer-certificate-orchestrator/src/lib.rs
+++ b/crates/agglayer-certificate-orchestrator/src/lib.rs
@@ -85,6 +85,7 @@ where
     /// # use tokio_stream::wrappers::BroadcastStream;
     /// # use tokio_util::sync::CancellationToken;
     /// # use futures_util::future::BoxFuture;
+    /// # use tokio_stream::StreamExt;
     ///
     /// ##[derive(Clone)]
     /// pub struct AggregatorNotifier {}
@@ -105,7 +106,7 @@ where
     ///
     /// async fn start() -> Result<(), ()> {
     ///    let (sender, receiver) = tokio::sync::broadcast::channel(1);
-    ///    let clock_stream = BroadcastStream::new(sender.subscribe());
+    ///    let clock_stream = BroadcastStream::new(sender.subscribe()).filter_map(|value| value.ok());
     ///    let notifier = AggregatorNotifier::new();
     ///    let data_receiver = tokio::sync::mpsc::channel(1).1;
     ///
@@ -113,7 +114,7 @@ where
     ///      .clock(clock_stream)
     ///      .data_receiver(data_receiver)
     ///      .cancellation_token(CancellationToken::new())
-    ///      .notification_task_builder(notifier)
+    ///      .epoch_packing_task_builder(notifier)
     ///      .start()
     ///      .await
     ///      .unwrap();

--- a/crates/agglayer-clock/src/block.rs
+++ b/crates/agglayer-clock/src/block.rs
@@ -239,12 +239,11 @@ mod tests {
         providers::{Provider, Ws},
         utils::Anvil,
     };
+    use fail::FailScenario;
     use tokio::sync::broadcast;
     use tokio_util::sync::CancellationToken;
 
-    use crate::{
-        block::BlockClockError, BlockClock, Clock, ClockRef, Event, BROADCAST_CHANNEL_SIZE,
-    };
+    use crate::{block::BlockClockError, BlockClock, Clock, Event, BROADCAST_CHANNEL_SIZE};
 
     #[test]
     fn test_block_calculation() {
@@ -327,6 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_clock_overflow() {
+        let scenario = FailScenario::setup();
         let anvil = Anvil::new().block_time(1u64).spawn();
         let client = Provider::<Ws>::connect(anvil.ws_endpoint()).await.unwrap();
 
@@ -356,11 +356,14 @@ mod tests {
             res,
             Err(BlockClockError::SetBlockHeight(height)) if height == u64::MAX - 1
         ));
+        scenario.teardown();
     }
 
     #[tokio::test]
     async fn test_block_clock_overflow_epoch() {
+        let scenario = FailScenario::setup();
         let anvil = Anvil::new().block_time(1u64).spawn();
+
         let client = Provider::<Ws>::connect(anvil.ws_endpoint()).await.unwrap();
 
         let mut clock = BlockClock::new(client, 0, NonZeroU64::new(3).unwrap());
@@ -388,5 +391,6 @@ mod tests {
             res,
             Err(BlockClockError::SetEpochNumber(u64::MAX, 0))
         ));
+        scenario.teardown();
     }
 }

--- a/crates/agglayer-node/src/rpc/tests.rs
+++ b/crates/agglayer-node/src/rpc/tests.rs
@@ -116,7 +116,14 @@ async fn send_certificate_method_can_be_called() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
 
-    let config = Arc::new(Config::default());
+    let mut config = Config::default();
+    let addr = next_available_addr();
+    if let IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+    let config = Arc::new(config);
+
     let (provider, _mock) = providers::Provider::mocked();
     let (certificate_sender, mut certificate_receiver) = tokio::sync::mpsc::channel(1);
 


### PR DESCRIPTION
# Description

`cargo test` were sometimes failing due to concurrency issue that are covered and backed by `nextest`.
This PR fixes the issue regarding the `addr` already in used discovered by @iljakuklic
It also fixes a concurrency issue with `fail`.

Why it does not fail on the CI ?
We're using `nextest`, which is a more advance and more performant test runner. Clusterisation/concurrency are handled differently between `cargo-test` and `nextest`.

### What to do

We can either enforce having both `nextest` and `cargo-test` tested on the CI or advertise that we only support nextest.

- Supporting both can be slower on a day to day as we'll have to replicate some logic provided by nextest or ignore some tests.
- Not providing `cargo-test` full support can lead users to not understand why some tests are failing.

My two-cents is that we could define clearly (in the README) that tests should be run with `nextest`, in order to not slow down the development and keep the important feature of nextest.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
